### PR TITLE
Implement local Base44-compatible client, remove Base44 deps, and fix Vite alias

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="https://base44.com/logo_v2.svg" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Base44 APP</title>
+    <title>Verdent Vision</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@base44/sdk": "^0.8.3",
-    "@base44/vite-plugin": "^0.2.5",
     "@hello-pangea/dnd": "^17.0.0",
     "@hookform/resolvers": "^4.1.2",
     "@radix-ui/react-accordion": "^1.2.3",

--- a/src/api/base44Client.js
+++ b/src/api/base44Client.js
@@ -1,0 +1,257 @@
+import { appParams } from '@/lib/app-params';
+
+const memoryStore = new Map();
+
+const getStorage = () => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+
+  return {
+    getItem: (key) => memoryStore.get(key) ?? null,
+    setItem: (key, value) => memoryStore.set(key, value),
+    removeItem: (key) => memoryStore.delete(key)
+  };
+};
+
+const storage = getStorage();
+const APP_KEY_PREFIX = `verdent_vision_${appParams.appId || 'local'}`;
+const getKey = (entityName) => `${APP_KEY_PREFIX}_${entityName}`;
+const USER_KEY = `${APP_KEY_PREFIX}_current_user`;
+
+const nowIso = () => new Date().toISOString();
+const createId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `id_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+};
+
+const readCollection = (entityName) => {
+  const raw = storage.getItem(getKey(entityName));
+  if (!raw) return [];
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+};
+
+const writeCollection = (entityName, records) => {
+  storage.setItem(getKey(entityName), JSON.stringify(records));
+};
+
+const sortRecords = (records, sort = '') => {
+  if (!sort) return records;
+  const isDesc = sort.startsWith('-');
+  const field = isDesc ? sort.slice(1) : sort;
+
+  return [...records].sort((a, b) => {
+    const av = a?.[field];
+    const bv = b?.[field];
+    if (av === bv) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (av > bv) return isDesc ? -1 : 1;
+    return isDesc ? 1 : -1;
+  });
+};
+
+const applyLimit = (records, limit) => {
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return records;
+  }
+  return records.slice(0, limit);
+};
+
+const matchesFilterValue = (recordValue, expectedValue) => {
+  if (Array.isArray(recordValue)) {
+    if (Array.isArray(expectedValue)) {
+      return expectedValue.every((item) => recordValue.includes(item));
+    }
+    return recordValue.includes(expectedValue);
+  }
+
+  if (Array.isArray(expectedValue)) {
+    return expectedValue.includes(recordValue);
+  }
+
+  return recordValue === expectedValue;
+};
+
+const getCurrentUser = () => {
+  const saved = storage.getItem(USER_KEY);
+  if (saved) {
+    return JSON.parse(saved);
+  }
+
+  const fallbackUser = {
+    id: 'local-user',
+    full_name: 'Local Farmer',
+    email: 'local@example.com',
+    role: 'user',
+    location: 'Demo Farm Region',
+    primary_crops: ['Tomatoes', 'Corn']
+  };
+
+  storage.setItem(USER_KEY, JSON.stringify(fallbackUser));
+  return fallbackUser;
+};
+
+const createEntityApi = (entityName) => ({
+  async list(sort = '', limit) {
+    return applyLimit(sortRecords(readCollection(entityName), sort), limit);
+  },
+
+  async filter(filters = {}, sort = '', limit) {
+    const filtered = readCollection(entityName).filter((item) =>
+      Object.entries(filters).every(([key, value]) => matchesFilterValue(item?.[key], value))
+    );
+    return applyLimit(sortRecords(filtered, sort), limit);
+  },
+
+  async create(data = {}) {
+    const user = getCurrentUser();
+    const timestamp = nowIso();
+    const record = {
+      id: createId(),
+      created_date: timestamp,
+      updated_date: timestamp,
+      created_by: user.id,
+      ...data
+    };
+
+    const current = readCollection(entityName);
+    writeCollection(entityName, [record, ...current]);
+    return record;
+  },
+
+  async update(id, data = {}) {
+    const current = readCollection(entityName);
+    let updated = null;
+    const next = current.map((item) => {
+      if (item.id !== id) return item;
+      updated = { ...item, ...data, updated_date: nowIso() };
+      return updated;
+    });
+
+    writeCollection(entityName, next);
+    return updated;
+  },
+
+  async delete(id) {
+    const current = readCollection(entityName);
+    const next = current.filter((item) => item.id !== id);
+    writeCollection(entityName, next);
+    return { success: true, id };
+  }
+});
+
+const pickEnum = (schema) => {
+  if (Array.isArray(schema?.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+  return undefined;
+};
+
+const generateFromSchema = (schema, key = '') => {
+  const enumValue = pickEnum(schema);
+  if (enumValue !== undefined) return enumValue;
+
+  if (schema?.type === 'object') {
+    return Object.fromEntries(
+      Object.entries(schema.properties || {}).map(([prop, child]) => [prop, generateFromSchema(child, prop)])
+    );
+  }
+
+  if (schema?.type === 'array') {
+    return [generateFromSchema(schema.items || { type: 'string' }, key)];
+  }
+
+  if (schema?.type === 'number' || schema?.type === 'integer') {
+    if (key.toLowerCase().includes('temperature')) return 72;
+    if (key.toLowerCase().includes('humidity')) return 55;
+    if (key.toLowerCase().includes('week')) return 1;
+    return 1;
+  }
+
+  if (schema?.type === 'boolean') {
+    return false;
+  }
+
+  if (key.toLowerCase().includes('date')) {
+    return new Date().toISOString().slice(0, 10);
+  }
+
+  return `${key || 'value'}_sample`;
+};
+
+const buildLlmResponse = ({ prompt = '', response_json_schema }) => {
+  if (response_json_schema) {
+    return generateFromSchema(response_json_schema);
+  }
+
+  const normalizedPrompt = String(prompt).toLowerCase();
+  if (normalizedPrompt.includes('weather')) {
+    return 'Current conditions look moderate with light winds. Recommend early-morning irrigation and pest scouting before sunset.';
+  }
+
+  return 'Here is a practical recommendation: monitor soil moisture daily, inspect leaves for pests every 2-3 days, and apply balanced nutrients based on crop stage.';
+};
+
+const entities = new Proxy(
+  {},
+  {
+    get: (_, entityName) => createEntityApi(entityName)
+  }
+);
+
+export const base44 = {
+  auth: {
+    async me() {
+      return getCurrentUser();
+    },
+    async updateMe(updateData = {}) {
+      const currentUser = getCurrentUser();
+      const nextUser = { ...currentUser, ...updateData, updated_date: nowIso() };
+      storage.setItem(USER_KEY, JSON.stringify(nextUser));
+      return nextUser;
+    },
+    logout(redirectUrl) {
+      storage.removeItem(USER_KEY);
+      if (redirectUrl && typeof window !== 'undefined') {
+        window.location.href = redirectUrl;
+      }
+    },
+    redirectToLogin(redirectUrl) {
+      if (typeof window !== 'undefined') {
+        window.location.href = redirectUrl || '/';
+      }
+    }
+  },
+
+  entities,
+
+  integrations: {
+    Core: {
+      async UploadFile({ file }) {
+        const fileName = typeof file === 'object' && file?.name ? file.name : 'uploaded-file';
+        if (typeof window !== 'undefined' && typeof file === 'object' && file) {
+          return { file_url: URL.createObjectURL(file), file_name: fileName };
+        }
+
+        return { file_url: `local://uploads/${fileName}`, file_name: fileName };
+      },
+      async InvokeLLM(payload = {}) {
+        return buildLlmResponse(payload);
+      }
+    }
+  },
+
+  appLogs: {
+    async logUserInApp(pageName) {
+      return { success: true, page: pageName, at: nowIso() };
+    }
+  }
+};

--- a/src/lib/AuthContext.jsx
+++ b/src/lib/AuthContext.jsx
@@ -1,7 +1,6 @@
 import React, { createContext, useState, useContext, useEffect } from 'react';
 import { base44 } from '@/api/base44Client';
 import { appParams } from '@/lib/app-params';
-import { createAxiosClient } from '@base44/sdk/dist/utils/axios-client';
 
 const AuthContext = createContext();
 
@@ -21,61 +20,17 @@ export const AuthProvider = ({ children }) => {
     try {
       setIsLoadingPublicSettings(true);
       setAuthError(null);
-      
-      // First, check app public settings (with token if available)
-      // This will tell us if auth is required, user not registered, etc.
-      const appClient = createAxiosClient({
-        baseURL: `${appParams.serverUrl}/api/apps/public`,
-        headers: {
-          'X-App-Id': appParams.appId
-        },
-        token: appParams.token, // Include token if available
-        interceptResponses: true
+
+      // Local mode: store app configuration from URL/env and treat it as available.
+      setAppPublicSettings({
+        id: appParams.appId || 'local-app',
+        public_settings: {
+          mode: 'local'
+        }
       });
-      
-      try {
-        const publicSettings = await appClient.get(`/prod/public-settings/by-id/${appParams.appId}`);
-        setAppPublicSettings(publicSettings);
-        
-        // If we got the app public settings successfully, check if user is authenticated
-        if (appParams.token) {
-          await checkUserAuth();
-        } else {
-          setIsLoadingAuth(false);
-          setIsAuthenticated(false);
-        }
-        setIsLoadingPublicSettings(false);
-      } catch (appError) {
-        console.error('App state check failed:', appError);
-        
-        // Handle app-level errors
-        if (appError.status === 403 && appError.data?.extra_data?.reason) {
-          const reason = appError.data.extra_data.reason;
-          if (reason === 'auth_required') {
-            setAuthError({
-              type: 'auth_required',
-              message: 'Authentication required'
-            });
-          } else if (reason === 'user_not_registered') {
-            setAuthError({
-              type: 'user_not_registered',
-              message: 'User not registered for this app'
-            });
-          } else {
-            setAuthError({
-              type: reason,
-              message: appError.message
-            });
-          }
-        } else {
-          setAuthError({
-            type: 'unknown',
-            message: appError.message || 'Failed to load app'
-          });
-        }
-        setIsLoadingPublicSettings(false);
-        setIsLoadingAuth(false);
-      }
+
+      await checkUserAuth();
+      setIsLoadingPublicSettings(false);
     } catch (error) {
       console.error('Unexpected error:', error);
       setAuthError({

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,15 +1,12 @@
-import base44 from "@base44/vite-plugin"
-import react from '@vitejs/plugin-react'
-import { defineConfig } from 'vite'
+import path from 'node:path';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
-// https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    base44({
-      // Support for legacy code that imports the base44 SDK with @/integrations, @/entities, etc.
-      // can be removed if the code has been updated to use the new SDK imports from @base44/sdk
-      legacySDKImports: process.env.BASE44_LEGACY_SDK_IMPORTS === 'true'
-    }),
-    react(),
-  ]
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
 });


### PR DESCRIPTION
### Motivation
- Remove runtime/build failures caused by unavailable private Base44 packages and plugin so the app can bootstrap and run in offline or restricted registries. 
- Provide a local compatibility layer that preserves existing `base44.*` callsites so pages and components keep working without external SDKs. 
- Simplify authentication and startup logic to rely on the local client and app params instead of remote axios helpers and the unavailable plugin.

### Description
- Added a local SDK-compatible client at `src/api/base44Client.js` implementing `base44.auth` (`me`, `updateMe`, `logout`, `redirectToLogin`), `base44.entities` (CRUD with `list`, `filter`, `create`, `update`, `delete`, sorting and limits), `base44.integrations.Core` (`UploadFile`, `InvokeLLM`), and `base44.appLogs.logUserInApp` fallbacks. 
- Simplified `src/lib/AuthContext.jsx` to use the local `base44.auth.me()` flow and local `appParams` for public settings instead of the removed axios-based app checks. 
- Removed Base44 runtime/plugin dependencies from `package.json` and removed the `@base44/vite-plugin` usage from `vite.config.js`, adding an explicit alias `@` → `./src` for module resolution. 
- Replaced Base44 branding in `index.html` (title and favicon) and kept upload/LLM fallbacks that return schema-shaped objects when `response_json_schema` is provided for structured flows.

### Testing
- Ran a production build with `npm run build`, which completed successfully and produced the `dist` artifacts. 
- Started the dev server and executed a Playwright-based smoke navigation over app routes (`/`, `/Home`, `/Dashboard`, `/Schedule`, `/Planner`, `/Diagnose`, `/Community`, `/Admin`, `/Treatments`, `/Chat`, `/Profile`, `/Predictions`, `/PestIdentifier`), and no console/page errors were captured. 
- `npm run lint` failed in this environment due to a missing external dependency (`eslint-plugin-react`) in the installed packages, so linting could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b440d100483328de64abd94e69cfb)