### PR TITLE
Add production-style auth, single-admin enforcement, and local AI assistant improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import PageNotFound from './lib/PageNotFound';
 import { AuthProvider, useAuth } from '@/lib/AuthContext';
 import UserNotRegisteredError from '@/components/UserNotRegisteredError';
 import Login from '@/pages/Login';
+import Signup from '@/pages/Signup';
 
 const { Pages, Layout, mainPage } = pagesConfig;
 const mainPageKey = mainPage ?? Object.keys(Pages)[0];
@@ -35,6 +36,7 @@ const AuthenticatedApp = () => {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<Signup />} />
 
       {!isAuthenticated ? (
         <Route path="*" element={<Navigate to="/login" replace />} />

--- a/src/components/admin/InviteUserForm.jsx
+++ b/src/components/admin/InviteUserForm.jsx
@@ -5,19 +5,17 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { X, Loader2, Mail, CheckCircle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
 export default function InviteUserForm({ onClose }) {
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState("user");
   const [success, setSuccess] = useState(false);
   const queryClient = useQueryClient();
 
   const inviteMutation = useMutation({
     mutationFn: async () => {
-      await appClient.users.inviteUser(email, role);
+      await appClient.users.inviteUser(email);
     },
     onSuccess: () => {
       setSuccess(true);
@@ -51,7 +49,7 @@ export default function InviteUserForm({ onClose }) {
           <Alert className="bg-green-50 border-green-200">
             <CheckCircle className="h-4 w-4 text-green-600" />
             <AlertDescription className="text-green-800">
-              Invitation sent successfully! User will receive an email with login instructions.
+              Invitation sent successfully. Admin rights are reserved only for charlesabhishekreddy@gmail.com.
             </AlertDescription>
           </Alert>
         ) : (
@@ -67,29 +65,6 @@ export default function InviteUserForm({ onClose }) {
                 required
                 disabled={inviteMutation.isPending}
               />
-            </div>
-
-            <div>
-              <Label htmlFor="role">User Role *</Label>
-              <Select value={role} onValueChange={setRole} disabled={inviteMutation.isPending}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="user">
-                    <div>
-                      <div className="font-medium">Regular User</div>
-                      <div className="text-xs text-gray-500">Can access all farming features</div>
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="admin">
-                    <div>
-                      <div className="font-medium">Administrator</div>
-                      <div className="text-xs text-gray-500">Full access including user management</div>
-                    </div>
-                  </SelectItem>
-                </SelectContent>
-              </Select>
             </div>
 
             {inviteMutation.isError && (

--- a/src/lib/AuthContext.jsx
+++ b/src/lib/AuthContext.jsx
@@ -39,6 +39,22 @@ export const AuthProvider = ({ children }) => {
     return currentUser;
   };
 
+  const signInWithEmail = async (payload) => {
+    const currentUser = await appClient.auth.signInWithEmail(payload);
+    setUser(currentUser);
+    setIsAuthenticated(true);
+    setAuthError(null);
+    return currentUser;
+  };
+
+  const registerWithEmail = async (payload) => {
+    const currentUser = await appClient.auth.registerWithEmail(payload);
+    setUser(currentUser);
+    setIsAuthenticated(true);
+    setAuthError(null);
+    return currentUser;
+  };
+
   const logout = (shouldRedirect = true) => {
     setUser(null);
     setIsAuthenticated(false);
@@ -59,6 +75,8 @@ export const AuthProvider = ({ children }) => {
       authError,
       appPublicSettings,
       signInWithGoogle,
+      signInWithEmail,
+      registerWithEmail,
       logout,
       navigateToLogin,
       checkAppState,

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -21,7 +21,7 @@ export default function Admin() {
       setCurrentUser(user);
 
       if (user.role !== 'admin') {
-        setError('Admin access requires an approved admin Google account. Set VITE_ADMIN_EMAILS to your gmail.');
+        setError('Admin access is restricted. Only charlesabhishekreddy@gmail.com has admin rights.');
         return [];
       }
       return appClient.entities.User.list('-created_date', 100);

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { GraduationCap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/lib/AuthContext';
+
+export default function Signup() {
+  const { registerWithEmail } = useAuth();
+  const navigate = useNavigate();
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+    try {
+      await registerWithEmail({ fullName, email, password });
+      navigate('/Home');
+    } catch (err) {
+      setError(err?.message || 'Sign up failed.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f2f4f7] grid md:grid-cols-2">
+      <div className="hidden md:flex bg-gradient-to-b from-[#13264f] to-[#233f7e] text-white p-12 items-center justify-center">
+        <div className="max-w-md text-center space-y-8">
+          <div className="mx-auto bg-white w-16 h-16 rounded-xl flex items-center justify-center">
+            <GraduationCap className="text-[#1f4d9b]" />
+          </div>
+          <h1 className="text-5xl font-bold">Create your account.</h1>
+          <p className="text-lg text-blue-100">Join Verdent Vision to manage farms, diagnostics, and AI-powered planning.</p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center p-6">
+        <div className="w-full max-w-md rounded-3xl bg-white border p-8 shadow-xl space-y-5">
+          <h2 className="text-4xl font-bold">Sign Up</h2>
+          <p className="text-slate-500">Already have an account? <Link className="text-sky-600 font-semibold" to="/login">Sign in</Link></p>
+
+          <form onSubmit={onSubmit} className="space-y-4">
+            <Input placeholder="Full name" value={fullName} onChange={(e) => setFullName(e.target.value)} required />
+            <Input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+            <Input placeholder="Password (min 8 chars)" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={8} />
+            <Input placeholder="Confirm password" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required minLength={8} />
+            <Button type="submit" className="w-full bg-sky-500 hover:bg-sky-600 text-white">Create Account</Button>
+            {error && <p className="text-sm text-red-600">{error}</p>}
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a production-like authentication foundation (email/password + Google) and a clear single-admin policy for the app. 
- Offer a more useful local AI assistant response behavior for the chat/pest-diagnosis flows. 
- Complete login/signup UI and prevent invite-based privilege escalation so admin rights are auditable and restricted.

### Description
- Implemented a hardened local auth/data layer in `src/api/appClient.js` including email/password registration (`registerWithEmail`), email sign-in (`signInWithEmail`), SHA-256 password hashing, auth event logging (`AuthEvent`), activity logging (`ActivityLog`), session handling, and a single-admin policy tied to `ADMIN_EMAIL` (`charlesabhishekreddy@gmail.com`).
- Upgraded AI behavior in `appClient.integrations.Core.InvokeLLM` to return practical agriculture guidance for prompt-based calls while still supporting schema-driven mock outputs. 
- Added `signInWithEmail` and `registerWithEmail` to the auth provider in `src/lib/AuthContext.jsx` and exposed them via the context. 
- Added full `Signup` page (`src/pages/Signup.jsx`) and redesigned `Login` (`src/pages/Login.jsx`) to include Google + email/password flows and account-type selector, and wired routing changes in `src/App.jsx`. 
- Prevented admin elevation through invites by simplifying `InviteUserForm` (`src/components/admin/InviteUserForm.jsx`) and updated admin panel messaging in `src/pages/Admin.jsx` to reflect the single-admin enforcement.

### Testing
- Ran lint with `npm run lint` which failed in this environment due to missing local dependency (`Cannot find package '/workspace/VerdentVisionFinal/node_modules/globals/index.js'`), so linting issues could not be fully validated. (failed)
- Attempted build with `npm run build` but the `vite` binary was unavailable in the current environment, so production build could not be validated here. (failed)
- Attempted an automated Playwright screenshot against `http://localhost:4173/login` to exercise the new UI, but the local dev server was not reachable (`ERR_EMPTY_RESPONSE`), so end-to-end rendering could not be confirmed. (failed)

Notes: the PR focuses on a secure local/demo auth baseline, single-admin enforcement, and practical AI responses; for full production use you should connect these flows to a real backend, secure storage, and a managed OAuth provider/secret store before deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4006ee6c8332b9240d3df16ad9c6)